### PR TITLE
travis, appveyor should test node current and LTS; travis should also run tests on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
     - "8"
+    - "10"
 before_install:
     - npm i -g npm@latest
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "8"
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
Revise travis and appveyor configs so that testing is on done with node current and LTS releases. Also enable travis testing on macOS (`osx`).